### PR TITLE
Fix for wrong `keys` and `values` output.

### DIFF
--- a/multi_indexed_collection.py
+++ b/multi_indexed_collection.py
@@ -383,7 +383,7 @@ class MultiIndexedCollection():
         if property_name:
             return self._dicts[property_name].values()
         else:
-            return self._propdict.values()
+            return self._propdict.keys()
 
     def items(self, property_name):
         """Returns an iterator of all items stored in this collection"""
@@ -397,7 +397,7 @@ class MultiIndexedCollection():
         if property_name:
             return self._dicts[property_name].keys()
         else:
-            return self._propdict.keys()
+            return self._propdict.values()
 
     def items_props(self):
         """An iterator of all contained items as tuples, where the key is the item, and the value is a dictionary of (property names->property values)"""

--- a/multi_indexed_collection.py
+++ b/multi_indexed_collection.py
@@ -381,9 +381,9 @@ class MultiIndexedCollection():
         Otherwise, it will only return objects that have the property `prop`.
         """
         if property_name:
-            return self._dicts[property_name].keys()
+            return self._dicts[property_name].values()
         else:
-            return self._propdict.keys()
+            return self._propdict.values()
 
     def items(self, property_name):
         """Returns an iterator of all items stored in this collection"""
@@ -395,9 +395,9 @@ class MultiIndexedCollection():
         When the optional `prop` is not given, it will return an iterator of all property names.
         """
         if property_name:
-            return self._propdict.keys()
-        else:
             return self._dicts[property_name].keys()
+        else:
+            return self._propdict.keys()
 
     def items_props(self):
         """An iterator of all contained items as tuples, where the key is the item, and the value is a dictionary of (property names->property values)"""


### PR DESCRIPTION
The `keys` and `values` methods gave wrong output. Here's a small fix.